### PR TITLE
Fix plugin to work with vagrant 1.4.0+

### DIFF
--- a/lib/auto_network/action/load_pool.rb
+++ b/lib/auto_network/action/load_pool.rb
@@ -6,7 +6,11 @@ class AutoNetwork::Action::LoadPool
   def initialize(app, env)
     @app, @env = app, env
 
-    @config_path = @env[:home_path].join('auto_network')
+    if @env[:home_path]
+      @config_path = @env[:home_path].join('auto_network')
+    else
+      @config_path = Pathname.new('~/.vagrant.d/auto_network')
+    end
     @statefile   = @config_path.join('pool.yaml')
   end
 
@@ -35,7 +39,11 @@ class AutoNetwork::Action::LoadPool
       pool = YAML.load(@statefile.read)
     else
       range = AutoNetwork.default_pool
-      @env[:ui].info "No auto_network pool available, generating a pool with the range #{range}"
+      if @env[:ui]
+        @env[:ui].info "No auto_network pool available, generating a pool with the range #{range}"
+      else
+        @env.ui.info "No auto_network pool available, generating a pool with the range #{range}"
+      end
       pool = AutoNetwork::Pool.new(range)
     end
     @env[:auto_network_pool] = pool


### PR DESCRIPTION
Vagrant 1.4.0+ doesn't always have env[:home_path] set. I didn't try to find out why. This fix is a bit of a hack, since it just defaults to the .vagrant.d directory in the user's home. As for the ui object, it looks like it changed from a hash variable to an instance variable of the environment class.

We tested this in our project team with Vagrant 1.3.5 and 1.4.3 on Ubuntu 12.10, and plugin works fine for us.
