### PR TITLE
Bump default Vagrant version to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
 
 matrix:
   include:
-    - rvm: 2.0.0
-      env: TEST_VAGRANT_VERSION=v1.7.4 BUNDLER_VERSION=1.10.5
     - rvm: 2.2.5
       env: TEST_VAGRANT_VERSION=v1.8.7 BUNDLER_VERSION=1.12.5
     - rvm: 2.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ matrix:
     - rvm: 2.4.4
       env: TEST_VAGRANT_VERSION=v2.1.2 BUNDLER_VERSION=1.16.1
     - rvm: 2.4.4
+      env: TEST_VAGRANT_VERSION=v2.2.2 BUNDLER_VERSION=1.16.1
+    - rvm: 2.4.4
       env: TEST_VAGRANT_VERSION=HEAD BUNDLER_VERSION=1.16.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 require 'rubygems/version'
 
-vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.1.2'
+vagrant_branch = ENV['TEST_VAGRANT_VERSION'] || 'v2.2.2'
 vagrant_version = nil
 
 # Wrapping gemspec in the :plugins group causes Vagrant 1.5 and newer to

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,0 +1,3 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
This commit adds testing for Vagrant 2.2.2 and updates the default to
2.2.2.